### PR TITLE
if checksum > 9 then turn to 0

### DIFF
--- a/src/JMBG.php
+++ b/src/JMBG.php
@@ -206,6 +206,10 @@ class JMBG
         foreach ($arr as $k => $v) $$k = (int)$v;
 
         $checksum = 11 - (7 * ($A + $G) + 6 * ($B + $H) + 5 * ($C + $I) + 4 * ($D + $J) + 3 * ($E + $K) + 2 * ($F + $L)) % 11;
+        if ($checksum > 9){
+            $checksum = 0;
+        }
+
         return ($checksum == $M);
     }
 


### PR DESCRIPTION
JMBG that has a last digit 0 is invalid,
 based on this article https://www.facebook.com/notes/zanimljive-informacije/jmbg-jedinstveni-mati%C4%8Dni-broj-gra%C4%91ana-i-zna%C4%8Denje-svih-13-cifara/177139098995081/,
 and the fact that none of the valid JMBGs pass validation